### PR TITLE
Backlinks update

### DIFF
--- a/backlinks/backlinks.qml
+++ b/backlinks/backlinks.qml
@@ -6,6 +6,7 @@ QtObject {
     property string backlinksHtml
     property bool triggerOnPreview
     property string dirSep
+    property bool useAtxHeadings;
 
     property variant settingsVariables: [
         {
@@ -15,6 +16,13 @@ QtObject {
             "type": "boolean",
             "default": false,
         },
+        {
+            "identifier": "useAtxHeadings",
+            "name": "Use ATX headings",
+            "description": "Use ATX-style Markdown headings (uncheck if using Setext-style)",
+            "type": "boolean",
+            "default": true,
+        }
     ];
 
     function getSubFolder(note, path) {
@@ -83,10 +91,9 @@ QtObject {
                 }
                 if (isBacklink == true) {
                     var fullPath = pageObj.fullNoteFilePath;
-                    var title = "";
-                    var titleMatch = text.match(/^# (.*)/);
-                    if (titleMatch) {
-                        title = titleMatch[1];
+                    var title = text.split("\n")[0];
+                    if (useAtxHeadings) {
+                        title = title.replace(/^# /, "");
                     }
                     var backlinkObj = {"p":fullPath, "t":title};
                     backlinks.push(backlinkObj);

--- a/backlinks/backlinks.qml
+++ b/backlinks/backlinks.qml
@@ -53,7 +53,7 @@ QtObject {
             for (var i = 0; i < backlinks.length; i++) {
                 var backlinkPath = backlinks[i]["p"];
                 var backlinkTitle = backlinks[i]["t"];
-                out += "    <li><a href=\"file://" + backlinkPath + "\">" + backlinkTitle + "</a></li>\n";
+                out += "    <li><a href=\"file://" + backlinkPath + "\" title=\"" + backlinkPath + "\">" + backlinkTitle + "</a></li>\n";
             }
             out += "</ul>\n";
         }


### PR DESCRIPTION
Add support for Setext-style Markdown headings in Backlinks script (as per discussion in #227).

Included an option to not bother stripping ATX headers if Setext-only headers are being used for all notes.

Also added link titles to the generated list of links.